### PR TITLE
Feature/specific events

### DIFF
--- a/Darnton.Blazor.Leaflet/InteropObject.cs
+++ b/Darnton.Blazor.Leaflet/InteropObject.cs
@@ -38,7 +38,7 @@ namespace Blazor.Leaflet.OpenStreetMap
         protected abstract Task<IJSObjectReference> CreateJsObjectRef();
 
         /// <inheritdoc/>
-        public async ValueTask DisposeAsync()
+        public virtual async ValueTask DisposeAsync()
         {
             if (JSObjectReference != null)
                 await JSObjectReference.DisposeAsync();
@@ -55,6 +55,6 @@ namespace Blazor.Leaflet.OpenStreetMap
             {
                 throw new InvalidOperationException(nullBindingMessage);
             }
-        }
+        }        
     }
 }

--- a/Darnton.Blazor.Leaflet/LeafletMap/LeafletEventArgs.cs
+++ b/Darnton.Blazor.Leaflet/LeafletMap/LeafletEventArgs.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
+{
+    /// <summary>
+    /// The base leaflet event object. All other leaflet event objects contain these properties too.
+    /// </summary>
+    public class LeafletEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The event type (e.g. 'click').
+        /// </summary>
+        public string Type { get; set; }   
+    }
+}

--- a/Darnton.Blazor.Leaflet/LeafletMap/LeafletMouseEventArgs.cs
+++ b/Darnton.Blazor.Leaflet/LeafletMap/LeafletMouseEventArgs.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
+{
+    /// <summary>
+    /// Represents a mouse interaction event
+    /// </summary>
+    public class LeafletMouseEventArgs : LeafletEventArgs
+    {
+        /// <summary>
+        /// The geographical point where the mouse event occurred.
+        /// </summary>
+        public LatLng LatLng { get; set; }
+
+        /// <summary>
+        /// Pixel coordinates of the point where the mouse event occurred relative to the map layer.
+        /// </summary>
+        public Point LayerPoint { get; set; }
+
+        /// <summary>
+        /// Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.
+        /// </summary>
+        public Point ContainerPoint { get; set; }
+
+        /// <summary>
+        ///	The original DOM MouseEvent or DOM TouchEvent that triggered this Leaflet event.
+        /// </summary>
+        public object OriginalEvent {get; set;}
+    }
+}

--- a/Darnton.Blazor.Leaflet/LeafletMap/Map.cs
+++ b/Darnton.Blazor.Leaflet/LeafletMap/Map.cs
@@ -20,6 +20,52 @@ namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
         public event EventHandler OnMoveEnd;
 
         /// <summary>
+        /// Fired when the user clicks (or taps) the map.
+        /// </summary>
+        public EventHandler<LeafletMouseEventArgs> OnClick;
+
+        /// <summary>
+        /// Fired when the user double-clicks (or double-taps) the map.
+        /// </summary>
+        public EventHandler<LeafletMouseEventArgs> OnDoubleClick;
+
+        /// <summary>
+        /// Fired when the user pushes the mouse button on the map.
+        /// </summary>
+        public EventHandler<LeafletMouseEventArgs> OnMouseDown;
+
+        /// <summary>
+        /// Fired when the user releases the mouse button on the map.
+        /// </summary>
+        public EventHandler<LeafletMouseEventArgs> OnMouseUp;
+
+        /// <summary>
+        /// Fired when the mouse enters the map.
+        /// </summary>
+        public EventHandler<LeafletMouseEventArgs> OnMouseOver;
+
+        /// <summary>
+        /// Fired when the mouse leaves the map.
+        /// </summary>
+        public EventHandler<LeafletMouseEventArgs> OnMouseOut;
+
+        /// <summary>
+        /// Fired while the mouse moves over the map.
+        /// </summary>
+        public EventHandler<LeafletMouseEventArgs> OnMouseMove;
+
+        /// <summary>
+        /// Fired when the user pushes the right mouse button on the map, prevents default browser context menu from showing if there are listeners on this event. Also fired on mobile when the user holds a single touch for a second (also called long press).
+        /// </summary>
+        public EventHandler<LeafletMouseEventArgs> OnContextMenu;
+
+        /// <summary>
+        /// Fired before mouse click on the map (sometimes useful when you want something to happen on click before any existing click handlers start running).
+        /// </summary>
+        public EventHandler<LeafletMouseEventArgs> OnPreClick;
+
+
+        /// <summary>
         /// The ID of the HTML element the map will be rendered in.
         /// </summary>
         public string ElementId { get; }
@@ -188,6 +234,13 @@ namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
             await module.InvokeVoidAsync("LeafletMap.Map.subscribeToEvent", JSObjectReference, objectReference, eventName, handlerName);            
         }
 
+        private async Task SubscribeToMouseEvent(string eventName, string handlerName)
+        {
+            objectReference = objectReference ?? DotNetObjectReference.Create(this);
+            var module = await JSBinder.GetLeafletMapModule();
+            await module.InvokeVoidAsync("LeafletMap.Map.subscribeToMouseEvent", JSObjectReference, objectReference, eventName, handlerName);            
+        }
+
         /// <summary>
         /// Subscribe to the map events. Unless this is called the map will not raise events.
         /// </summary>
@@ -196,18 +249,86 @@ namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
             if (!subscribedToEvents)
             {
                 Console.WriteLine("Subscribing to events");
-                await SubscribeToEvent("moveend", nameof(InvokeOnMoveEnd));                     
+                await SubscribeToEvent("moveend", nameof(InvokeOnMoveEnd));                    
+                await SubscribeToMouseEvent("click", nameof(InvokeOnClick)); 
+                await SubscribeToMouseEvent("dblclick", nameof(InvokeOnDoubleClick));
+                await SubscribeToMouseEvent("mousedown", nameof(InvokeOnMouseDown));
+                await SubscribeToMouseEvent("mouseup", nameof(InvokeOnMouseUp));
+                await SubscribeToMouseEvent("mouseover", nameof(InvokeOnMouseOver));
+                await SubscribeToMouseEvent("mouseout", nameof(InvokeOnMouseOut));
+                await SubscribeToMouseEvent("mousemove", nameof(InvokeOnMouseMove));
+                await SubscribeToMouseEvent("contextmenu", nameof(InvokeOnContextMenu));
+                
+                //This one causes a DOM Exception:
+                //await SubscribeToMouseEvent("preclick", nameof(InvokeOnPreClick));
+
                 subscribedToEvents = true;
             }
         }
 
-        [JSInvokable]
         ///<summary>
         /// This method is public for Javascript interop, do not invoke manally
         ///</summary>
+        [JSInvokable]
         public void InvokeOnMoveEnd() => OnMoveEnd?.Invoke(this, new EventArgs());       
 
+        ///<summary>
+        /// This method is public for Javascript interop, do not invoke manally
+        ///</summary>
+        [JSInvokable]
+        public void InvokeOnClick(LeafletMouseEventArgs args) => OnClick?.Invoke(this, args);
 
+        ///<summary>
+        /// This method is public for Javascript interop, do not invoke manally
+        ///</summary>
+        [JSInvokable]
+        public void InvokeOnDoubleClick(LeafletMouseEventArgs args) => OnDoubleClick?.Invoke(this, args);
+
+        ///<summary>
+        /// This method is public for Javascript interop, do not invoke manally
+        ///</summary>
+        [JSInvokable]
+        public void InvokeOnMouseDown(LeafletMouseEventArgs args) => OnMouseDown?.Invoke(this, args);
+
+        ///<summary>
+        /// This method is public for Javascript interop, do not invoke manally
+        ///</summary>
+        [JSInvokable]
+        public void InvokeOnMouseUp(LeafletMouseEventArgs args) => OnMouseUp?.Invoke(this, args);
+
+        ///<summary>
+        /// This method is public for Javascript interop, do not invoke manally
+        ///</summary>
+        [JSInvokable]
+        public void InvokeOnMouseOver(LeafletMouseEventArgs args) => OnMouseOver?.Invoke(this, args);
+
+        ///<summary>
+        /// This method is public for Javascript interop, do not invoke manally
+        ///</summary>
+        [JSInvokable]
+        public void InvokeOnMouseOut(LeafletMouseEventArgs args) => OnMouseOut?.Invoke(this, args);
+
+        ///<summary>
+        /// This method is public for Javascript interop, do not invoke manally
+        ///</summary>
+        [JSInvokable]
+        public void InvokeOnMouseMove(LeafletMouseEventArgs args) => OnMouseMove?.Invoke(this, args);
+
+        ///<summary>
+        /// This method is public for Javascript interop, do not invoke manally
+        ///</summary>
+        [JSInvokable]
+        public void InvokeOnContextMenu(LeafletMouseEventArgs args) => OnContextMenu?.Invoke(this, args);
+
+        ///<summary>
+        /// This method is public for Javascript interop, do not invoke manally
+        ///</summary>
+        [JSInvokable]
+        public void InvokeOnPreClick(LeafletMouseEventArgs args) => OnPreClick?.Invoke(this, args);
+
+        /// <summary>
+        /// Dispose
+        /// </summary>
         public override async ValueTask DisposeAsync()
         {
             await base.DisposeAsync();

--- a/Darnton.Blazor.Leaflet/wwwroot/js/leaflet-map.js
+++ b/Darnton.Blazor.Leaflet/wwwroot/js/leaflet-map.js
@@ -4,7 +4,13 @@
 
         setView: function (map, center, zoom) {
             map.setView(center, zoom);
-        }
+        },
+
+        subscribeToEvent(map, dotNetReference, eventName, handlerName) {            
+            map.on(eventName, function(e) {                
+                dotNetReference.invokeMethodAsync(handlerName);
+            });
+        }   
 
     },
 

--- a/Darnton.Blazor.Leaflet/wwwroot/js/leaflet-map.js
+++ b/Darnton.Blazor.Leaflet/wwwroot/js/leaflet-map.js
@@ -10,8 +10,23 @@
             map.on(eventName, function(e) {                
                 dotNetReference.invokeMethodAsync(handlerName);
             });
-        }   
+        },   
 
+        subscribeToMouseEvent(map, dotNetReference, eventName, handlerName) {            
+            map.on(eventName, function(e) {                
+                var args = {
+                    "type" : e.type.toString(),
+                    "latlng" : e.latlng,
+                    "layerPoint" : e.layerPoint,
+                    "containerPoint" : e.containerPoint,
+                    "originalEvent" : e.originalEvent,
+                    // "target" : e.target.toString(),
+                    // "sourceTarget" : e.sourceTarget,
+                    // "propagatedFrom" : e.propagatedFrom,
+                };                
+                dotNetReference.invokeMethodAsync(handlerName, args);
+            });
+        }
     },
 
     Layer: {


### PR DESCRIPTION
It's a lot of grunt work inside the library, but for the consumers it should be simple.

The idea is to add support for every specific Leaflet Event (MouseEvent, KeyboardEvent, etc...) and then
transfer the relevant arguments from JavaScript to C#.

So far I've implemented the Map events of type `MouseEvent`

    - OnClick
    - OnDoubleClick
    - OnMouseDown
    - OnMouseUp
    - OnMouseOver
    - OnMouseOut
    - OnMouseMove
    - OnContextMenu
    - OnPreClick

Unless you see a problem with this approach I will continue adding support for other events if my free time permits it.