### PR TITLE
Some fixes

### DIFF
--- a/Darnton.Blazor.Leaflet/Blazor.Leaflet.OpenStreetMap.csproj
+++ b/Darnton.Blazor.Leaflet/Blazor.Leaflet.OpenStreetMap.csproj
@@ -5,7 +5,7 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Blazor.Leaflet.OpenStreetMap</PackageId>
-    <Version>0.2.2</Version>
+    <Version>0.2.4</Version>
     <Authors>Bernard Darnton, Stoyan Bonchev</Authors>
     <Company>Bernard Darnton</Company>
     <Product>Leaflet.js Interop Library for Blazor</Product>

--- a/Darnton.Blazor.Leaflet/Blazor.Leaflet.OpenStreetMap.csproj
+++ b/Darnton.Blazor.Leaflet/Blazor.Leaflet.OpenStreetMap.csproj
@@ -20,6 +20,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <StaticWebAssetBasePath>_content/$(PackageId)</StaticWebAssetBasePath>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Remove="LeafletBlazor.xml" />

--- a/Darnton.Blazor.Leaflet/LeafletMap/LatLng.cs
+++ b/Darnton.Blazor.Leaflet/LeafletMap/LatLng.cs
@@ -15,11 +15,15 @@ namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
         /// </summary>
         [JsonPropertyName("lat")]
         public double Lat { get; set; }
+
+        
+        private double _lng; 
+
         /// <summary>
         /// Longitude in degrees.
         /// </summary>
         [JsonPropertyName("lng")]
-        public double Lng { get; set; }
+        public double Lng { get => _lng; set => _lng = value % 360.0; }
 
         /// <summary>
         /// Constructs a LatLng

--- a/Darnton.Blazor.Leaflet/LeafletMap/LeafletMap.razor.cs
+++ b/Darnton.Blazor.Leaflet/LeafletMap/LeafletMap.razor.cs
@@ -23,6 +23,7 @@ namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
         /// </summary>
         [Parameter] public TileLayer TileLayer { get; set; }
 
+ 
         /// <inheritdoc/>
         protected async override Task OnAfterRenderAsync(bool firstRender)
         {
@@ -30,6 +31,7 @@ namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
             {
                 await Map.BindJsObjectReference(new LeafletMapJSBinder(JSRuntime));
                 await TileLayer.AddTo(Map);
+                await Map.SubscribeToEvents();
             }
         }
     }

--- a/Darnton.Blazor.Leaflet/LeafletMap/Map.cs
+++ b/Darnton.Blazor.Leaflet/LeafletMap/Map.cs
@@ -90,7 +90,7 @@ namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
         {
             return await JSBinder.JSRuntime.InvokeAsync<IJSObjectReference>("L.map", ElementId, Options);
         }
-
+        
         #region Get map state
         /// <summary>
         /// Gets the point at the centre of the map view.
@@ -242,11 +242,20 @@ namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
         }
 
         /// <summary>
+        /// Subscribe to the map events. Unless this is set true the map will not raise events.
+        /// </summary>
+        public bool SubscribeEvents { get; set; }
+
+        /// <summary>
         /// Subscribe to the map events. Unless this is called the map will not raise events.
         /// </summary>
-        public async Task SubscribeToEvents()
+        internal async Task SubscribeToEvents()
         {
-            if (!subscribedToEvents)
+            if (JSBinder is null)
+            {
+                throw new InvalidOperationException("JSBinder has not been bind yet.");
+            }
+            if (SubscribeEvents && !subscribedToEvents)
             {
                 Console.WriteLine("Subscribing to events");
                 await SubscribeToEvent("moveend", nameof(InvokeOnMoveEnd));                    

--- a/Darnton.Blazor.Leaflet/LeafletMap/Marker.cs
+++ b/Darnton.Blazor.Leaflet/LeafletMap/Marker.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.JSInterop;
+using System;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
@@ -13,7 +14,7 @@ namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
         /// <summary>
         /// The initial position of the marker.
         /// </summary>
-        [JsonIgnore] public LatLng LatLng { get; }
+        [JsonIgnore] public LatLng LatLng { get; private set; }
         /// <summary>
         /// The <see cref="MarkerOptions"/> used to create the marker.
         /// </summary>
@@ -28,6 +29,18 @@ namespace Blazor.Leaflet.OpenStreetMap.LeafletMap
         {
             LatLng = latlng;
             Options = options;
+        }
+
+        /// <summary>
+        /// Changes the marker position to the given point.
+        /// </summary>
+        /// <param name="latlng">Coordinates of the new position of the marker.</param>
+        public async Task SetLatLng(LatLng latlng)
+        {
+            GuardAgainstNullBinding("Cannot set marker position. No JavaScript binding has been set up.");
+            var module = await JSBinder.GetLeafletMapModule();
+            await module.InvokeVoidAsync("LeafletMap.Marker.setLatLng", latlng, JSObjectReference);
+            LatLng = latlng;
         }
 
         /// <inheritdoc/>

--- a/Darnton.Blazor.Leaflet/wwwroot/js/leaflet-map.js
+++ b/Darnton.Blazor.Leaflet/wwwroot/js/leaflet-map.js
@@ -50,8 +50,12 @@
     },
 
     Marker: {
-        setIcon(icon, marker) {
+        setIcon (icon, marker) {
             marker.setIcon(icon);
+        },
+
+        setLatLng(latlng, marker) {
+            marker.setLatLng(latlng);
         }
     },
 

--- a/LeafletBlazorTestRig/Pages/Index.razor
+++ b/LeafletBlazorTestRig/Pages/Index.razor
@@ -10,6 +10,14 @@
 <div class="my-3">
     <EditForm Model="MapStateViewModel" OnValidSubmit="SetMapState">
         <h3>Map State</h3>
+        @if (!(ClickLocation is null))
+        {
+            <p>You clicked at : @(ClickLocation.ToString())</p>
+        }
+        else
+        {
+            <p>Click on the map to find out the coordinates (lat, lon).</p>
+         }
         <button class="btn btn-primary my-3" @onclick="GetMapState">Get Map State</button>
         <button type="submit" class="btn btn-primary my-3">Set Map State</button>
         <div class="form-row">

--- a/LeafletBlazorTestRig/Pages/Index.razor.cs
+++ b/LeafletBlazorTestRig/Pages/Index.razor.cs
@@ -38,9 +38,17 @@ namespace LeafletBlazorTestRig.Pages
             );
 
             MarkerViewModel = new MarkerViewModel();
-
+            PositionMap.SubscribeEvents = true;
+            PositionMap.OnClick += MapClicked;
         }
 
+        public LatLng ClickLocation { get; set; }
+        private void MapClicked(object sender, LeafletMouseEventArgs e)
+        {
+            Console.WriteLine("Click event at: " + e.LatLng.ToString());
+            ClickLocation = e.LatLng;
+            StateHasChanged();
+        }
         protected async void GetMapState()
         {
             var mapCentre = await PositionMap.GetCenter();

--- a/LeafletBlazorTestRig/Pages/Index.razor.cs
+++ b/LeafletBlazorTestRig/Pages/Index.razor.cs
@@ -12,7 +12,7 @@ namespace LeafletBlazorTestRig.Pages
         protected TileLayer OpenStreetMapsTileLayer;
         protected MapStateViewModel MapStateViewModel;
         protected MarkerViewModel MarkerViewModel;
-
+        private Marker _marker;
 
         public IndexBase() : base()
         {
@@ -41,12 +41,13 @@ namespace LeafletBlazorTestRig.Pages
             PositionMap.SubscribeEvents = true;
             PositionMap.OnClick += MapClicked;
         }
-
+        
         public LatLng ClickLocation { get; set; }
-        private void MapClicked(object sender, LeafletMouseEventArgs e)
+        private async void MapClicked(object sender, LeafletMouseEventArgs e)
         {
             Console.WriteLine("Click event at: " + e.LatLng.ToString());
             ClickLocation = e.LatLng;
+            await AddOrMoveClickMarker(e.LatLng);
             StateHasChanged();
         }
         protected async void GetMapState()
@@ -67,6 +68,27 @@ namespace LeafletBlazorTestRig.Pages
             await PositionMap.SetView(mapCentre, MapStateViewModel.Zoom);
         }
 
+        private async Task AddOrMoveClickMarker(LatLng latLng)
+        {
+            if (_marker is null)
+            {
+                _marker = new Marker(latLng, new MarkerOptions
+                {
+                    Keyboard = MarkerViewModel.Keyboard,
+                    Title = MarkerViewModel.Title,
+                    Alt = MarkerViewModel.Alt,
+                    ZIndexOffset = MarkerViewModel.ZIndexOffset,
+                    Opacity = MarkerViewModel.Opacity,
+                    RiseOnHover = MarkerViewModel.RiseOnHover,
+                    RiseOffset = MarkerViewModel.RiseOffset,
+                });
+                await _marker.AddTo(PositionMap);
+            }
+            else
+            {
+                await _marker.SetLatLng(latLng);
+            }
+        }
         protected async void AddMarkerAtMapCenter()
         {
             var mapCentre = await PositionMap.GetCenter();


### PR DESCRIPTION
- project file now contains StaticWebAssetBasePath so that leaflet-map.js will be available after installing nuget package.

- Refactored event subscription. When attempted to call SubscribeToEvents() from the Page constructor or inside OnInitialized or OnParametersSet methods, JSBinder was still null and that caused an error. Now   SubscribeToEvents() is internal and is called from the LeafletRazor.Map.cs. The user can subscribe to events by setting Map.SubscribeEvents = true

- Added an OnClick event example to index page.  
 
- Corrected LatLon.Lng property. Longitude could have values > 360 degrees. 